### PR TITLE
fix: correct timestamp timezone conversion in gateway route

### DIFF
--- a/app/api/gateway/route.ts
+++ b/app/api/gateway/route.ts
@@ -6,6 +6,12 @@ import { parseInstantaneousFlow } from "@/utils/parseInstantaneousFlow";
 import { parseTemperature } from "@/utils/parseTemperature";
 import { parseTimestamp } from "@/utils/parseTimestamp ";
 import { PrismaClient } from "@prisma/client";
+import dayjs from "dayjs";
+import utc from "dayjs/plugin/utc";
+import timezone from "dayjs/plugin/timezone";
+
+dayjs.extend(utc);
+dayjs.extend(timezone);
 
 const prisma = new PrismaClient();
 
@@ -77,7 +83,9 @@ export async function POST(request: Request) {
     const reading = await prisma.reading.create({
       data: {
         meter_id: meter.id,
-        timestamp: new Date(timestamp * 1000).toISOString(),
+        timestamp: dayjs(timestamp * 1000)
+          .tz("America/Argentina/Buenos_Aires")
+          .format("YYYY-MM-DDTHH:mm:ss.SSS[Z]"),
         plot: data,
         fCnt,
         fPort,

--- a/app/api/gateway/route.ts
+++ b/app/api/gateway/route.ts
@@ -6,12 +6,7 @@ import { parseInstantaneousFlow } from "@/utils/parseInstantaneousFlow";
 import { parseTemperature } from "@/utils/parseTemperature";
 import { parseTimestamp } from "@/utils/parseTimestamp ";
 import { PrismaClient } from "@prisma/client";
-import dayjs from "dayjs";
-import utc from "dayjs/plugin/utc";
-import timezone from "dayjs/plugin/timezone";
-
-dayjs.extend(utc);
-dayjs.extend(timezone);
+import { convertTimestampToArgentinaTime } from "@/utils/timestampConverter";
 
 const prisma = new PrismaClient();
 
@@ -83,9 +78,7 @@ export async function POST(request: Request) {
     const reading = await prisma.reading.create({
       data: {
         meter_id: meter.id,
-        timestamp: dayjs(timestamp * 1000)
-          .tz("America/Argentina/Buenos_Aires")
-          .format("YYYY-MM-DDTHH:mm:ss.SSS[Z]"),
+        timestamp: convertTimestampToArgentinaTime(timestamp),
         plot: data,
         fCnt,
         fPort,

--- a/utils/timestampConverter.ts
+++ b/utils/timestampConverter.ts
@@ -1,0 +1,41 @@
+import dayjs from "dayjs";
+import utc from "dayjs/plugin/utc";
+import timezone from "dayjs/plugin/timezone";
+
+dayjs.extend(utc);
+dayjs.extend(timezone);
+
+/**
+ * Converts a Unix timestamp (in seconds) to Argentina timezone ISO string
+ * @param timestamp - Unix timestamp in seconds
+ * @returns ISO string in Argentina timezone (UTC-3)
+ */
+export const convertTimestampToArgentinaTime = (timestamp: number): string => {
+  return dayjs(timestamp * 1000)
+    .tz("America/Argentina/Buenos_Aires")
+    .format("YYYY-MM-DDTHH:mm:ss.SSS[Z]");
+};
+
+/**
+ * Converts a Unix timestamp (in seconds) to a specific timezone ISO string
+ * @param timestamp - Unix timestamp in seconds
+ * @param timezone - Timezone string (e.g., "America/Argentina/Buenos_Aires")
+ * @returns ISO string in the specified timezone
+ */
+export const convertTimestampToTimezone = (
+  timestamp: number,
+  timezone: string
+): string => {
+  return dayjs(timestamp * 1000)
+    .tz(timezone)
+    .format("YYYY-MM-DDTHH:mm:ss.SSS[Z]");
+};
+
+/**
+ * Converts a Unix timestamp (in seconds) to UTC ISO string
+ * @param timestamp - Unix timestamp in seconds
+ * @returns ISO string in UTC
+ */
+export const convertTimestampToUTC = (timestamp: number): string => {
+  return dayjs(timestamp * 1000).toISOString();
+};


### PR DESCRIPTION
# Fix: Correct timestamp timezone conversion in gateway route

## 🐛 Problem
The gateway route was saving timestamps with incorrect timezone conversion. The timestamps were being saved in UTC instead of Argentina timezone (UTC-3), causing a 3-hour offset in the database.

## 🔍 Root Cause
- The gateway sends timestamps in **seconds** (Unix timestamp format)
- The code was correctly converting seconds to milliseconds (`timestamp * 1000`)
- However, `.toISOString()` always converts to UTC regardless of the timezone set with `.tz()`
- This caused timestamps to be saved with +3 hours offset

## ✅ Solution
- Added dayjs timezone plugins for proper timezone handling
- Changed from `.toISOString()` to `.format("YYYY-MM-DDTHH:mm:ss.SSS[Z]")` to preserve timezone
- Now timestamps are correctly converted to Argentina timezone (`America/Argentina/Buenos_Aires`)

## 📝 Changes
- **File**: `app/api/gateway/route.ts`
- **Added**: dayjs timezone plugins (`utc`, `timezone`)
- **Modified**: timestamp conversion logic to preserve timezone

## 🧪 Testing
- ✅ Verified timestamp `1754142401` converts correctly
- ✅ Before: `2025-08-02T13:46:41.000Z` (UTC)
- ✅ After: `2025-08-02T10:46:41.000Z` (Argentina time)

## 📋 Checklist
- [x] Code follows project conventions
- [x] No breaking changes introduced
- [x] Timestamps now save with correct timezone
- [x] Gateway functionality remains intact

## 🔗 Related Issues
Fixes timestamp timezone offset issue in gateway data processing