### PR TITLE
feat(dashboard): add last reading timestamp to stats API

### DIFF
--- a/app/api/dashboard/stats/route.ts
+++ b/app/api/dashboard/stats/route.ts
@@ -192,6 +192,26 @@ export async function GET() {
       activeCooperatives = 0;
     }
 
+    // Obtener timestamp de la última lectura
+    let lastReadingTimestamp = null;
+    try {
+      const lastReading = await prisma.reading.findFirst({
+        orderBy: {
+          timestamp: "desc",
+        },
+        select: {
+          timestamp: true,
+        },
+      });
+      lastReadingTimestamp = lastReading?.timestamp || null;
+    } catch (error) {
+      console.error(
+        "[DASHBOARD STATS] Error obteniendo última lectura:",
+        error
+      );
+      lastReadingTimestamp = null;
+    }
+
     // Por ahora, usar valores por defecto para los estados
     const userCounts = {
       total: totalUsers,
@@ -234,6 +254,7 @@ export async function GET() {
             ? "GOOD"
             : "ATTENTION",
       },
+      lastReadingTimestamp,
     };
 
     return NextResponse.json(response);

--- a/components/dashboard/home/home-dashboard.tsx
+++ b/components/dashboard/home/home-dashboard.tsx
@@ -45,10 +45,8 @@ export function HomeDashboard() {
           <Clock className="w-4 h-4" />
           <span>
             Última actualización:{" "}
-            {consumption?.series && consumption.series.length > 0
-              ? formatLastUpdate(
-                  consumption.series[consumption.series.length - 1].fecha
-                )
+            {stats?.lastReadingTimestamp
+              ? formatLastUpdate(stats.lastReadingTimestamp)
               : "Sin datos"}
           </span>
         </div>

--- a/hooks/dashboard/use-dashboard-stats.ts
+++ b/hooks/dashboard/use-dashboard-stats.ts
@@ -32,6 +32,7 @@ export interface DashboardStats {
     totalEntities: number;
     systemHealth: "EXCELLENT" | "GOOD" | "ATTENTION";
   };
+  lastReadingTimestamp: string | null;
 }
 
 export const useDashboardStats = () => {


### PR DESCRIPTION
# feat(dashboard): Add last reading timestamp to stats API

## 📋 Summary
This PR improves the dashboard's "Last Update" display by showing the actual timestamp of the most recent reading instead of the consumption data grouping date.

## 🔧 Changes Made

### Backend Changes
- **API Enhancement**: Added `lastReadingTimestamp` field to `/api/dashboard/stats` endpoint
- **Database Query**: Added query to fetch the most recent reading timestamp from the database
- **Error Handling**: Proper error handling for the new timestamp query

### Frontend Changes
- **TypeScript Interface**: Updated `DashboardStats` interface to include `lastReadingTimestamp: string | null`
- **UI Update**: Modified home dashboard to use the real reading timestamp instead of consumption date
- **User Experience**: Users now see the actual time when data was last received by the platform

## 🎯 Problem Solved
- **Before**: Dashboard showed "Last Update" using consumption data grouping date (e.g., "2025-09-11" without time)
- **After**: Dashboard shows the real timestamp of the last reading received (e.g., "11/09/2025 21:00:00")

## ✅ Benefits
- More accurate data freshness indication
- Better user experience with precise timing information
- No impact on consumption calculation logic
- Real-time data visibility

## 🧪 Testing
- [x] API returns correct timestamp
- [x] Frontend displays formatted timestamp correctly
- [x] Fallback handling when no data is available
- [x] No breaking changes to existing functionality

## 📝 Technical Details
- Added `lastReadingTimestamp` to dashboard stats response
- Uses `prisma.reading.findFirst()` with `orderBy: { timestamp: 'desc' }`
- Maintains backward compatibility
- Follows conventional commit standards