### PR TITLE
feat: :art: fix: static data in vercel

### DIFF
--- a/app/api/cooperative/route.ts
+++ b/app/api/cooperative/route.ts
@@ -2,6 +2,8 @@
 import { PrismaClient } from "@prisma/client";
 import { NextResponse } from "next/server";
 
+export const dynamic = "force-dynamic";
+
 const prisma = new PrismaClient();
 
 export async function GET() {

--- a/app/api/dashboard/consumption/route.ts
+++ b/app/api/dashboard/consumption/route.ts
@@ -1,6 +1,8 @@
 import { NextResponse } from "next/server";
 import { PrismaClient } from "@prisma/client";
 
+export const dynamic = "force-dynamic";
+
 const prisma = new PrismaClient();
 
 type GroupBy = "day" | "month";

--- a/app/api/dashboard/meter-distribution/route.ts
+++ b/app/api/dashboard/meter-distribution/route.ts
@@ -1,6 +1,8 @@
 import { NextResponse } from "next/server";
 import { PrismaClient } from "@prisma/client";
 
+export const dynamic = "force-dynamic";
+
 const prisma = new PrismaClient();
 
 function parseISODate(s?: string | null): Date | null {

--- a/app/api/dashboard/stats/route.ts
+++ b/app/api/dashboard/stats/route.ts
@@ -1,6 +1,8 @@
 import { NextResponse } from "next/server";
 import { PrismaClient, MeterStatus } from "@prisma/client";
 
+export const dynamic = "force-dynamic";
+
 const prisma = new PrismaClient();
 
 function getOverallMeterStatus(statuses: MeterStatus[]): MeterStatus {

--- a/app/api/gateway/route.ts
+++ b/app/api/gateway/route.ts
@@ -3,6 +3,8 @@ import { parseMeterStatus } from "@/utils/parseMeterStatus";
 import { parseMeterData } from "@/utils/parseMeterData";
 import { parseFlowHex } from "@/utils/parseFlowHex";
 import { parseInstantaneousFlow } from "@/utils/parseInstantaneousFlow";
+
+export const dynamic = "force-dynamic";
 import { parseTemperature } from "@/utils/parseTemperature";
 import {
   parseTimestamp,

--- a/app/api/meter/[id]/readings/route.ts
+++ b/app/api/meter/[id]/readings/route.ts
@@ -2,6 +2,8 @@
 import { PrismaClient } from "@prisma/client";
 import { NextResponse } from "next/server";
 
+export const dynamic = "force-dynamic";
+
 function addDays(d: Date, n: number) {
   const x = new Date(d);
   x.setUTCDate(x.getUTCDate() + n);

--- a/app/api/meter/route.ts
+++ b/app/api/meter/route.ts
@@ -3,6 +3,8 @@ import { NextResponse } from "next/server";
 import { getPaginationParams } from "../../../utils/pagination";
 import { MeterStatus, PrismaClient } from "@prisma/client";
 
+export const dynamic = "force-dynamic";
+
 const prisma = new PrismaClient();
 
 export async function GET(req: Request) {

--- a/app/api/urgencies/route.ts
+++ b/app/api/urgencies/route.ts
@@ -7,6 +7,8 @@ import {
   StatusData,
 } from "@/utils/alertMapper";
 
+export const dynamic = "force-dynamic";
+
 const prisma = new PrismaClient();
 
 type UrgencyParams = {


### PR DESCRIPTION
# Fix: API Routes con Renderizado Estático en Vercel

**Branch:** `feature/ED-52-EPIC-3_new-features`
**Fecha:** 15/03/2026

---

## Problema

Los datos del dashboard **no se actualizaban en los ambientes deployados** (QA, Prod) a menos que se realizara un nuevo deploy o se subiera contenido nuevo.

### Síntomas observados

- "Última actualización" en el Home Dashboard mostraba la fecha del último deploy, no la fecha del último dato real.
- **Local** mostraba datos del `11/03/26` mientras **QA** mostraba datos del `08/03/26` (fecha del último redeploy).
- El contador de "Medidores en línea" mostraba valores incorrectos en QA (`2/3`) a pesar de no haber lecturas recientes, porque el estado quedaba congelado en build time.
- Los tres ambientes apuntan al mismo gateway LoRaWAN, por lo que la diferencia de datos descartaba un problema de ingesta.

### Error en el build log

```
[GET METERS WITH PAGINATION + STATUS] B [Error]: Dynamic server usage:
Route /api/meter couldn't be rendered statically because it used `request.url`.
See more info here: https://nextjs.org/docs/messages/dynamic-server-error

Error in urgencies API: B [Error]: Dynamic server usage:
Route /api/urgencies couldn't be rendered statically because it used `request.url`.
```

---

## Causa Raíz

**Next.js 14 App Router pre-renderiza las rutas API estáticamente por defecto** si no detecta el uso de funciones dinámicas (cookies, headers, etc.).

Las rutas del dashboard que no recibían parámetros en el `GET` (como `/api/dashboard/stats`) eran candidatas perfectas para el caché estático de Next.js. Durante el build, Next.js ejecutaba esas rutas contra la base de datos del momento del deploy, generaba una respuesta estática y la servía a todos los usuarios posteriores — sin volver a consultar la base de datos.

Las rutas que sí usaban `request.url` (como `/api/meter` y `/api/urgencies`) generaban un error de build porque Next.js intentaba renderizarlas estáticamente pero no podía. Ese error en el log era la pista clave.

### Por qué el build output lo confirmaba

```
○  (Static)   prerendered as static content   ← problema
ƒ  (Dynamic)  server-rendered on demand       ← correcto
```

Las rutas sin `force-dynamic` aparecían como `○ (Static)` en el output del build.

---

## Solución

Agregar `export const dynamic = "force-dynamic"` en todas las rutas API que sirven datos en tiempo real. Esto le indica explícitamente a Next.js que la ruta debe ejecutarse en cada request, nunca desde caché estático.

### Archivos modificados

| Archivo | Motivo |
|---|---|
| `app/api/dashboard/stats/route.ts` | **Crítico** — `GET()` sin parámetros era la ruta más susceptible al caché estático. Contiene el `lastReadingTimestamp` y los contadores del dashboard |
| `app/api/dashboard/consumption/route.ts` | Datos del gráfico de consumo principal |
| `app/api/dashboard/meter-distribution/route.ts` | Distribución de medidores por estado |
| `app/api/urgencies/route.ts` | Alertas activas. También elimina el error de build |
| `app/api/meter/route.ts` | Lista de medidores con paginación. También elimina el error de build |
| `app/api/meter/[id]/readings/route.ts` | Lecturas históricas por medidor |
| `app/api/gateway/route.ts` | Ingesta LoRaWAN — nunca debe quedar estático |
| `app/api/cooperative/route.ts` | Configuración de la cooperativa |

### Cambio aplicado (ejemplo)

```diff
// app/api/dashboard/stats/route.ts
import { NextResponse } from "next/server";
import { PrismaClient, MeterStatus } from "@prisma/client";

+ export const dynamic = "force-dynamic";
```

---

## Resultado esperado

Tras el deploy, el build output debe mostrar todas estas rutas como `ƒ (Dynamic)`:

```
ƒ /api/dashboard/stats
ƒ /api/dashboard/consumption
ƒ /api/dashboard/meter-distribution
ƒ /api/urgencies
ƒ /api/meter
ƒ /api/meter/[id]/readings
ƒ /api/gateway
ƒ /api/cooperative
```

Los datos del dashboard se actualizarán en tiempo real, en todos los ambientes, sin necesidad de redeploy.

---

## Notas adicionales

- Este problema ya había sido parcialmente abordado en el PR #35 (`fix-static-data-in-vercel`), pero quedaron rutas sin cubrir.
- El cron de Vercel (`/api/cron/update-meter-status`) **no era la causa** del problema — solo actualiza estados de medidores, no afecta la frescura de los datos del dashboard.
- La configuración de TanStack Query (`refetchInterval: 30s`, `staleTime: 10s`) funcionaba correctamente en todo momento; el problema era que la API devolvía datos cacheados del build, no datos frescos de la base de datos.
