### PR TITLE
Qa to main - gitflow

### DIFF
--- a/app/api/zones/[id]/downloads/route.ts
+++ b/app/api/zones/[id]/downloads/route.ts
@@ -5,7 +5,7 @@ const prisma = new PrismaClient();
 
 export async function GET(
   _req: Request,
-  { params }: { params: { id: string } }
+  { params }: { params: { id: string } },
 ) {
   try {
     const downloads = await prisma.zoneDownload.findMany({
@@ -14,7 +14,10 @@ export async function GET(
     });
     return NextResponse.json(downloads);
   } catch (e) {
-    return NextResponse.json({ error: "Error al obtener historial" }, { status: 500 });
+    return NextResponse.json(
+      { error: "Error al obtener historial" },
+      { status: 500 },
+    );
   } finally {
     await prisma.$disconnect().catch(() => {});
   }
@@ -22,14 +25,17 @@ export async function GET(
 
 export async function POST(
   req: Request,
-  { params }: { params: { id: string } }
+  { params }: { params: { id: string } },
 ) {
   try {
     const body = await req.json();
     const { period_start, period_end, meter_count, notes } = body;
 
     if (!period_start || !period_end || meter_count == null) {
-      return NextResponse.json({ error: "Faltan campos requeridos" }, { status: 400 });
+      return NextResponse.json(
+        { error: "Faltan campos requeridos" },
+        { status: 400 },
+      );
     }
 
     const download = await prisma.zoneDownload.create({
@@ -44,7 +50,10 @@ export async function POST(
 
     return NextResponse.json(download, { status: 201 });
   } catch (e) {
-    return NextResponse.json({ error: "Error al registrar descarga" }, { status: 500 });
+    return NextResponse.json(
+      { error: "Error al registrar descarga" },
+      { status: 500 },
+    );
   } finally {
     await prisma.$disconnect().catch(() => {});
   }
@@ -52,7 +61,7 @@ export async function POST(
 
 export async function PATCH(
   req: Request,
-  { params }: { params: { id: string } }
+  { params }: { params: { id: string } },
 ) {
   try {
     const body = await req.json();
@@ -73,7 +82,10 @@ export async function PATCH(
 
     return NextResponse.json(updated);
   } catch (e) {
-    return NextResponse.json({ error: "Error al actualizar descarga" }, { status: 500 });
+    return NextResponse.json(
+      { error: "Error al actualizar descarga" },
+      { status: 500 },
+    );
   } finally {
     await prisma.$disconnect().catch(() => {});
   }

--- a/app/api/zones/[id]/meters/route.ts
+++ b/app/api/zones/[id]/meters/route.ts
@@ -7,20 +7,56 @@ export const dynamic = "force-dynamic";
 
 const prisma = new PrismaClient();
 
+// Interpreta YYYY-MM-DD como inicio de dia en UTC-3.
+function parseStartOfDayUtcMinus3(dateInput: string): Date {
+  const [year, month, day] = dateInput.split("-").map(Number);
+  return new Date(Date.UTC(year, month - 1, day, 3, 0, 0, 0));
+}
+
+// Interpreta YYYY-MM-DD como fin de dia en UTC-3.
+function parseEndOfDayUtcMinus3(dateInput: string): Date {
+  const [year, month, day] = dateInput.split("-").map(Number);
+  return new Date(Date.UTC(year, month - 1, day + 1, 2, 59, 59, 999));
+}
+
+function getTodayDateInputUtcMinus3(): string {
+  const shifted = new Date(Date.now() - 3 * 60 * 60 * 1000);
+  const year = shifted.getUTCFullYear();
+  const month = String(shifted.getUTCMonth() + 1).padStart(2, "0");
+  const day = String(shifted.getUTCDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
+
 export async function GET(
-  _req: Request,
-  { params }: { params: { id: string } }
+  req: Request,
+  { params }: { params: { id: string } },
 ) {
   try {
     const zone = await prisma.zone.findUnique({ where: { id: params.id } });
     if (!zone) {
-      return NextResponse.json({ error: "Zona no encontrada" }, { status: 404 });
+      return NextResponse.json(
+        { error: "Zona no encontrada" },
+        { status: 404 },
+      );
     }
 
     const polygon = zone.polygon as unknown as PolygonPoint[];
 
-    const todayStart = new Date();
-    todayStart.setHours(0, 0, 0, 0);
+    const todayDateAR = getTodayDateInputUtcMinus3();
+    const [yearAR, monthAR] = todayDateAR.split("-").map(Number);
+    const currentBimesterStartMonth = monthAR % 2 === 0 ? monthAR - 1 : monthAR;
+    const defaultStartDate = `${yearAR}-${String(currentBimesterStartMonth).padStart(2, "0")}-01`;
+
+    const { searchParams } = new URL(req.url);
+    const startDateParam = searchParams.get("startDate");
+    const endDateParam = searchParams.get("endDate");
+
+    // Si no llegan fechas, usamos bimestre actual y cierre al "hoy" en UTC-3.
+    const startDateInput = startDateParam ?? defaultStartDate;
+    const endDateInput = endDateParam ?? todayDateAR;
+    const periodStart = parseStartOfDayUtcMinus3(startDateInput);
+    const periodEnd = parseEndOfDayUtcMinus3(endDateInput);
+    const todayStart = parseStartOfDayUtcMinus3(todayDateAR);
 
     const meters = await prisma.meter.findMany({
       where: {
@@ -41,41 +77,116 @@ export async function GET(
       },
     });
 
-    const inZone: ZoneMeter[] = meters
-      .filter((m) => pointInPolygon(m.lat!, m.lng!, polygon))
-      .map((m) => {
-        const user = m.userMeters[0]?.user ?? null;
-        const lastReading = m.readings[0] ?? null;
-        const read_today =
-          lastReading != null && lastReading.timestamp >= todayStart;
+    // Primero filtramos medidores dentro del poligono para evitar
+    // traer lecturas de medidores fuera de la zona.
+    const metersInZone = meters.filter((m) =>
+      pointInPolygon(m.lat!, m.lng!, polygon),
+    );
+    const meterIdsInZone = metersInZone.map((m) => m.id);
 
-        return {
-          id: m.id,
-          dev_eui: m.dev_eui,
-          device_name: m.device_name,
-          meter_type: m.meter_type,
-          street_address: m.street_address ?? null,
-          lat: m.lat,
-          lng: m.lng,
-          status: m.status,
-          userName: user
-            ? `${user.lastName ?? ""} ${user.firstName ?? ""}`.trim()
-            : null,
-          shortData: user?.address?.shortData ?? user?.address?.data ?? null,
-          cumulative_flow: lastReading?.cumulative_flow ?? null,
-          last_reading_value: lastReading?.instantaneous_flow ?? null,
-          last_reading_date: lastReading?.timestamp ?? null,
-          last_reading_observations: lastReading?.observations ?? null,
-          read_today,
-        };
+    // Lecturas del mes para cada medidor de la zona.
+    // Con esto obtenemos la primera y la ultima lectura del periodo actual.
+    const periodReadings = meterIdsInZone.length
+      ? await prisma.reading.findMany({
+          where: {
+            meter_id: { in: meterIdsInZone },
+            timestamp: { gte: periodStart, lte: periodEnd },
+          },
+          select: {
+            meter_id: true,
+            timestamp: true,
+            cumulative_flow: true,
+            observations: true,
+          },
+          orderBy: [{ meter_id: "asc" }, { timestamp: "asc" }],
+        })
+      : [];
+
+    // Estructuras en memoria para lookup O(1) durante el mapeo final.
+    const firstReadingInPeriodByMeter = new Map<string, string | null>();
+    const latestReadingInPeriodByMeter = new Map<string, string | null>();
+    const latestReadingMetaInPeriodByMeter = new Map<
+      string,
+      { timestamp: Date; observations: string | null }
+    >();
+    for (const reading of periodReadings) {
+      if (!firstReadingInPeriodByMeter.has(reading.meter_id)) {
+        firstReadingInPeriodByMeter.set(
+          reading.meter_id,
+          reading.cumulative_flow ?? null,
+        );
+      }
+      latestReadingInPeriodByMeter.set(
+        reading.meter_id,
+        reading.cumulative_flow ?? null,
+      );
+      latestReadingMetaInPeriodByMeter.set(reading.meter_id, {
+        timestamp: reading.timestamp,
+        observations: reading.observations ?? null,
       });
+    }
+
+    const toNumber = (value: string | null | undefined): number | null => {
+      if (!value) return null;
+      const parsed = Number(value);
+      return Number.isFinite(parsed) ? parsed : null;
+    };
+
+    const formatFlow = (value: number | null): string | null => {
+      if (value === null) return null;
+      return value.toFixed(3);
+    };
+
+    const inZone: ZoneMeter[] = metersInZone.map((m) => {
+      const user = m.userMeters[0]?.user ?? null;
+      const lastReading = m.readings[0] ?? null;
+      const read_today =
+        lastReading != null && lastReading.timestamp >= todayStart;
+      const latestPeriodCumulative = toNumber(
+        latestReadingInPeriodByMeter.get(m.id),
+      );
+      const latestPeriodMeta = latestReadingMetaInPeriodByMeter.get(m.id);
+      const firstPeriodCumulative = toNumber(
+        firstReadingInPeriodByMeter.get(m.id) ?? null,
+      );
+      // Consumo del periodo = ultimo acumulado del periodo - primer acumulado del periodo.
+      const monthCumulativeFlow =
+        latestPeriodCumulative !== null && firstPeriodCumulative !== null
+          ? formatFlow(
+              Math.max(0, latestPeriodCumulative - firstPeriodCumulative),
+            )
+          : null;
+
+      return {
+        id: m.id,
+        dev_eui: m.dev_eui,
+        device_name: m.device_name,
+        meter_type: m.meter_type,
+        street_address: m.street_address ?? null,
+        lat: m.lat,
+        lng: m.lng,
+        status: m.status,
+        userName: user
+          ? `${user.lastName ?? ""} ${user.firstName ?? ""}`.trim()
+          : null,
+        shortData: user?.address?.shortData ?? user?.address?.data ?? null,
+        cumulative_flow: lastReading?.cumulative_flow ?? null,
+        month_cumulative_flow: monthCumulativeFlow,
+        last_reading_value: lastReading?.instantaneous_flow ?? null,
+        // Para reporte por periodo, priorizamos fecha/obs de la ultima lectura dentro del periodo.
+        last_reading_date: latestPeriodMeta?.timestamp ?? lastReading?.timestamp ?? null,
+        last_reading_observations:
+          latestPeriodMeta?.observations ?? lastReading?.observations ?? null,
+        read_today,
+      };
+    });
 
     return NextResponse.json(inZone);
   } catch (error) {
     console.error("[GET ZONE METERS]", error);
     return NextResponse.json(
       { error: "Error al obtener medidores de la zona" },
-      { status: 500 }
+      { status: 500 },
     );
   }
 }

--- a/components/zonas/zone-detail.tsx
+++ b/components/zonas/zone-detail.tsx
@@ -36,17 +36,53 @@ import { usePageHeader } from "@/context/page-header-context";
 import ZoneAssignment from "@/components/operarios/zone-assignment";
 import { useOperariosQuery } from "@/hooks/operarios/use-operarios";
 import { Badge } from "@/components/ui/badge";
+import { getTodayDateInputAR } from "@/lib/utils";
 
 interface ZoneDetailProps {
   id: string;
+}
+
+function toDateInput(date: Date): string {
+  return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}-${String(date.getDate()).padStart(2, "0")}`;
+}
+
+function getCurrentBimesterRange(): { startDate: string; endDate: string } {
+  const todayAR = getTodayDateInputAR();
+  const [year, month] = todayAR.split("-").map(Number);
+  const bimesterStartMonth = month % 2 === 0 ? month - 1 : month;
+  return {
+    startDate: `${year}-${String(bimesterStartMonth).padStart(2, "0")}-01`,
+    endDate: todayAR,
+  };
+}
+
+function getPreviousBimesterRange(): { startDate: string; endDate: string } {
+  const todayAR = getTodayDateInputAR();
+  const [year, month] = todayAR.split("-").map(Number);
+  const now = new Date(year, month - 1, 1);
+  const currentStartMonthIdx = (now.getMonth() % 2 === 0 ? now.getMonth() : now.getMonth() - 1);
+  const previousStart = new Date(now.getFullYear(), currentStartMonthIdx - 2, 1);
+  const previousEnd = new Date(previousStart.getFullYear(), previousStart.getMonth() + 2, 0);
+  return {
+    startDate: toDateInput(previousStart),
+    endDate: toDateInput(previousEnd),
+  };
+}
+
+function isSamePeriod(
+  a: { startDate: string; endDate: string },
+  b: { startDate: string; endDate: string },
+): boolean {
+  return a.startDate === b.startDate && a.endDate === b.endDate;
 }
 
 export function ZoneDetail({ id }: ZoneDetailProps) {
   const router = useRouter();
   const { toast } = useToast();
   const { setPageHeader } = usePageHeader();
+  const [selectedPeriod, setSelectedPeriod] = useState(getCurrentBimesterRange);
   const { data: zone, isLoading: zoneLoading } = useZoneQuery(id);
-  const { data: meters, isLoading: metersLoading } = useZoneMetersQuery(id);
+  const { data: meters, isLoading: metersLoading } = useZoneMetersQuery(id, selectedPeriod);
   const { data: operariosData } = useOperariosQuery(1, "");
   // Filter operators assigned to this zone
   const assignedOperarios = operariosData?.data.filter((op) =>
@@ -64,6 +100,10 @@ export function ZoneDetail({ id }: ZoneDetailProps) {
   const [editing, setEditing] = useState(false);
   const [editName, setEditName] = useState("");
   const [editColor, setEditColor] = useState("");
+  const currentBimesterPeriod = getCurrentBimesterRange();
+  const previousBimesterPeriod = getPreviousBimesterRange();
+  const isCurrentBimesterSelected = isSamePeriod(selectedPeriod, currentBimesterPeriod);
+  const isPreviousBimesterSelected = isSamePeriod(selectedPeriod, previousBimesterPeriod);
 
   const startEdit = () => {
     setEditName(zone?.name ?? "");
@@ -152,6 +192,7 @@ export function ZoneDetail({ id }: ZoneDetailProps) {
               className="w-4 h-4 rounded-full border flex-shrink-0"
               style={{ backgroundColor: zone.color }}
             />
+            <span className="font-medium">{zone.name}</span>
             <Button size="sm" variant="ghost" onClick={startEdit} className="gap-1.5">
               <Pencil className="w-3.5 h-3.5" />
               Editar nombre
@@ -191,14 +232,57 @@ export function ZoneDetail({ id }: ZoneDetailProps) {
 
       {/* Meters table */}
       <div>
-        <h2 className="text-lg font-semibold mb-3">
-          Medidores en la zona{" "}
-          {!metersLoading && meters && (
-            <span className="text-muted-foreground font-normal text-sm">
-              ({meters.length})
-            </span>
-          )}
-        </h2>
+        <div className="mb-3 flex flex-col gap-2">
+          <Label>Periodo para tabla y descarga</Label>
+          <div className="flex flex-wrap items-center gap-2">
+            <Button
+              type="button"
+              size="sm"
+              variant={isCurrentBimesterSelected ? "default" : "outline"}
+              onClick={() => setSelectedPeriod(currentBimesterPeriod)}
+            >
+              Bimestre actual
+            </Button>
+            <Button
+              type="button"
+              size="sm"
+              variant={isPreviousBimesterSelected ? "default" : "outline"}
+              onClick={() => setSelectedPeriod(previousBimesterPeriod)}
+            >
+              Bimestre anterior
+            </Button>
+            <Input
+              type="date"
+              className="w-[170px]"
+              value={selectedPeriod.startDate}
+              onChange={(e) =>
+                setSelectedPeriod((prev) => ({ ...prev, startDate: e.target.value }))
+              }
+            />
+            <Input
+              type="date"
+              className="w-[170px]"
+              value={selectedPeriod.endDate}
+              onChange={(e) =>
+                setSelectedPeriod((prev) => ({ ...prev, endDate: e.target.value }))
+              }
+            />
+          </div>
+        </div>
+
+        <div className="mb-3">
+          <h2 className="text-lg font-semibold">
+            Medidores en la zona{" "}
+            {!metersLoading && meters && (
+              <span className="text-muted-foreground font-normal text-sm">
+                ({meters.length})
+              </span>
+            )}
+          </h2>
+          <p className="text-xs text-muted-foreground mt-1">
+            Acumulado para el periodo {selectedPeriod.startDate} {"->"} {selectedPeriod.endDate}
+          </p>
+        </div>
 
         {metersLoading ? (
           <div className="space-y-2">
@@ -218,7 +302,7 @@ export function ZoneDetail({ id }: ZoneDetailProps) {
                 <TableHead>Dispositivo</TableHead>
                 <TableHead>Usuario</TableHead>
                 <TableHead>Dirección</TableHead>
-                <TableHead>Última Lectura (m³)</TableHead>
+                <TableHead>Acumulado del periodo (m³)</TableHead>
                 <TableHead>Estado</TableHead>
                 <TableHead />
               </TableRow>
@@ -244,7 +328,7 @@ export function ZoneDetail({ id }: ZoneDetailProps) {
                   <TableCell className="max-w-[200px] truncate">
                     {m.meter_type === "MECHANICAL" ? m.street_address ?? "—" : m.shortData ?? "—"}
                   </TableCell>
-                  <TableCell>{m.last_reading_value ?? m.cumulative_flow ?? "—"}</TableCell>
+                  <TableCell>{m.month_cumulative_flow ?? "—"}</TableCell>
                   <TableCell>
                     <Chip status={m.status as any} />
                   </TableCell>
@@ -261,7 +345,13 @@ export function ZoneDetail({ id }: ZoneDetailProps) {
       </div>
 
       {/* Download history section */}
-      <ZoneDownloadSection zoneId={id} zoneName={zone.name} meters={meters} />
+      <ZoneDownloadSection
+        zoneId={id}
+        zoneName={zone.name}
+        meters={meters}
+        periodStart={selectedPeriod.startDate}
+        periodEnd={selectedPeriod.endDate}
+      />
 
       {/* Operators section */}
       <div>

--- a/components/zonas/zone-download-section.tsx
+++ b/components/zonas/zone-download-section.tsx
@@ -30,31 +30,8 @@ import {
   ZoneDownload,
 } from "@/hooks/zones/use-zone-downloads";
 import { downloadZoneCsv } from "@/lib/export-csv";
-import { formatDateAR, formatDateTimeShortAR } from "@/lib/utils";
+import { formatDateInputAR, formatDateTimeShortAR } from "@/lib/utils";
 import { ZoneMeter } from "@/types/zones/zone-types";
-
-const BIMESTER_LABELS = ["Ene-Feb", "Mar-Abr", "May-Jun", "Jul-Ago", "Sep-Oct", "Nov-Dic"];
-
-function getBimesterRange(year: number, index: number): { start: string; end: string } {
-  const startMonth = index * 2;
-  const start = new Date(year, startMonth, 1);
-  const end = new Date(year, startMonth + 2, 0);
-  return {
-    start: start.toISOString().slice(0, 10),
-    end: end.toISOString().slice(0, 10),
-  };
-}
-
-function getCurrentBimester(): { start: string; end: string } {
-  const now = new Date();
-  return getBimesterRange(now.getFullYear(), Math.floor(now.getMonth() / 2));
-}
-
-function getBimesterPresets(): Array<{ label: string; start: string; end: string }> {
-  const now = new Date();
-  const year = now.getFullYear();
-  return BIMESTER_LABELS.map((label, i) => ({ label, ...getBimesterRange(year, i) }));
-}
 
 function toDateInput(isoString: string): string {
   return isoString.slice(0, 10);
@@ -64,9 +41,17 @@ interface ZoneDownloadSectionProps {
   zoneId: string;
   zoneName: string;
   meters: ZoneMeter[] | undefined;
+  periodStart: string;
+  periodEnd: string;
 }
 
-export function ZoneDownloadSection({ zoneId, zoneName, meters }: ZoneDownloadSectionProps) {
+export function ZoneDownloadSection({
+  zoneId,
+  zoneName,
+  meters,
+  periodStart,
+  periodEnd,
+}: ZoneDownloadSectionProps) {
   const { toast } = useToast();
   const { data: downloads, isLoading } = useZoneDownloads(zoneId);
   const createDownload = useCreateZoneDownload(zoneId);
@@ -74,9 +59,6 @@ export function ZoneDownloadSection({ zoneId, zoneName, meters }: ZoneDownloadSe
 
   // Download dialog state
   const [dialogOpen, setDialogOpen] = useState(false);
-  const bimester = getCurrentBimester();
-  const [periodStart, setPeriodStart] = useState(bimester.start);
-  const [periodEnd, setPeriodEnd] = useState(bimester.end);
   const [notes, setNotes] = useState("");
 
   // Edit row state
@@ -86,9 +68,6 @@ export function ZoneDownloadSection({ zoneId, zoneName, meters }: ZoneDownloadSe
   const [editNotes, setEditNotes] = useState("");
 
   const openDialog = () => {
-    const b = getCurrentBimester();
-    setPeriodStart(b.start);
-    setPeriodEnd(b.end);
     setNotes("");
     setDialogOpen(true);
   };
@@ -96,7 +75,10 @@ export function ZoneDownloadSection({ zoneId, zoneName, meters }: ZoneDownloadSe
   const handleDownloadAndSave = async () => {
     if (!meters) return;
     try {
-      downloadZoneCsv(zoneName, meters);
+      downloadZoneCsv(zoneName, meters, {
+        startDate: periodStart,
+        endDate: periodEnd,
+      }, notes.trim() || undefined);
       await createDownload.mutateAsync({
         period_start: periodStart,
         period_end: periodEnd,
@@ -106,7 +88,10 @@ export function ZoneDownloadSection({ zoneId, zoneName, meters }: ZoneDownloadSe
       toast({ title: "Descarga registrada correctamente" });
       setDialogOpen(false);
     } catch {
-      toast({ title: "Error al registrar la descarga", variant: "destructive" });
+      toast({
+        title: "Error al registrar la descarga",
+        variant: "destructive",
+      });
     }
   };
 
@@ -125,7 +110,7 @@ export function ZoneDownloadSection({ zoneId, zoneName, meters }: ZoneDownloadSe
         download_id: downloadId,
         period_start: editStart,
         period_end: editEnd,
-        notes: editNotes.trim() || undefined,
+        notes: editNotes.trim() || "Sin observaciones",
       });
       setEditingId(null);
       toast({ title: "Descarga actualizada" });
@@ -136,20 +121,26 @@ export function ZoneDownloadSection({ zoneId, zoneName, meters }: ZoneDownloadSe
 
   return (
     <div>
-      <div className="flex items-center justify-between mb-3">
-        <h2 className="text-lg font-semibold flex items-center gap-2">
-          <History className="h-4 w-4" />
-          Historial de descargas
-        </h2>
+      <div className="flex items-center justify-between rounded-md border p-3 mb-4">
+        <div className="text-xs text-muted-foreground">
+          CSV del periodo {formatDateInputAR(periodStart)} {"->"}{" "}
+          {formatDateInputAR(periodEnd)}
+        </div>
         <Button
           variant="outline"
           size="sm"
           onClick={openDialog}
-          disabled={!meters || meters.length === 0}
-        >
+          disabled={!meters || meters.length === 0}>
           <Download className="w-4 h-4 mr-2" />
           Descargar CSV
         </Button>
+      </div>
+
+      <div className="flex items-center gap-2 mb-3">
+        <h2 className="text-lg font-semibold flex items-center gap-2">
+          <History className="h-4 w-4" />
+          Historial de descargas
+        </h2>
       </div>
 
       {isLoading ? (
@@ -213,16 +204,14 @@ export function ZoneDownloadSection({ zoneId, zoneName, meters }: ZoneDownloadSe
                         variant="ghost"
                         className="h-7 w-7"
                         onClick={() => saveEdit(d.id)}
-                        disabled={updateDownload.isPending}
-                      >
+                        disabled={updateDownload.isPending}>
                         <Check className="h-3.5 w-3.5 text-green-600" />
                       </Button>
                       <Button
                         size="icon"
                         variant="ghost"
                         className="h-7 w-7"
-                        onClick={cancelEdit}
-                      >
+                        onClick={cancelEdit}>
                         <X className="h-3.5 w-3.5" />
                       </Button>
                     </div>
@@ -234,9 +223,12 @@ export function ZoneDownloadSection({ zoneId, zoneName, meters }: ZoneDownloadSe
                     {formatDateTimeShortAR(d.downloaded_at)}
                   </TableCell>
                   <TableCell className="text-sm">
-                    {formatDateAR(d.period_start)} → {formatDateAR(d.period_end)}
+                    {formatDateInputAR(toDateInput(d.period_start))} →{" "}
+                    {formatDateInputAR(toDateInput(d.period_end))}
                   </TableCell>
-                  <TableCell className="text-center text-sm">{d.meter_count}</TableCell>
+                  <TableCell className="text-center text-sm">
+                    {d.meter_count}
+                  </TableCell>
                   <TableCell className="text-sm text-muted-foreground">
                     {d.notes ?? "—"}
                   </TableCell>
@@ -245,13 +237,12 @@ export function ZoneDownloadSection({ zoneId, zoneName, meters }: ZoneDownloadSe
                       size="icon"
                       variant="ghost"
                       className="h-7 w-7"
-                      onClick={() => startEdit(d)}
-                    >
+                      onClick={() => startEdit(d)}>
                       <Pencil className="h-3.5 w-3.5" />
                     </Button>
                   </TableCell>
                 </TableRow>
-              )
+              ),
             )}
           </TableBody>
         </Table>
@@ -264,46 +255,12 @@ export function ZoneDownloadSection({ zoneId, zoneName, meters }: ZoneDownloadSe
             <DialogTitle>Registrar descarga CSV</DialogTitle>
           </DialogHeader>
           <div className="flex flex-col gap-4 py-2">
-            {/* Bimester presets */}
             <div className="flex flex-col gap-1.5">
-              <Label>Bimestre {new Date().getFullYear()}</Label>
-              <div className="grid grid-cols-3 gap-1.5">
-                {getBimesterPresets().map((preset) => {
-                  const active = periodStart === preset.start && periodEnd === preset.end;
-                  return (
-                    <Button
-                      key={preset.label}
-                      type="button"
-                      size="sm"
-                      variant={active ? "default" : "outline"}
-                      className="text-xs h-8"
-                      onClick={() => {
-                        setPeriodStart(preset.start);
-                        setPeriodEnd(preset.end);
-                      }}
-                    >
-                      {preset.label}
-                    </Button>
-                  );
-                })}
-              </div>
-            </div>
-
-            {/* Custom range */}
-            <div className="flex flex-col gap-1.5">
-              <Label>Rango personalizado</Label>
-              <div className="grid grid-cols-2 gap-3">
-                <Input
-                  type="date"
-                  value={periodStart}
-                  onChange={(e) => setPeriodStart(e.target.value)}
-                />
-                <Input
-                  type="date"
-                  value={periodEnd}
-                  onChange={(e) => setPeriodEnd(e.target.value)}
-                />
-              </div>
+              <Label>Periodo seleccionado</Label>
+              <p className="text-sm text-muted-foreground">
+                {formatDateInputAR(periodStart)} {"->"}{" "}
+                {formatDateInputAR(periodEnd)}
+              </p>
             </div>
             <div className="flex flex-col gap-1.5">
               <Label htmlFor="notes">Observaciones (opcional)</Label>
@@ -316,14 +273,18 @@ export function ZoneDownloadSection({ zoneId, zoneName, meters }: ZoneDownloadSe
               />
             </div>
             <p className="text-xs text-muted-foreground">
-              Se descargarán los datos de <strong>{meters?.length ?? 0} medidores</strong> y la descarga quedará registrada en el historial.
+              Se descargarán los datos de{" "}
+              <strong>{meters?.length ?? 0} medidores</strong> y la descarga
+              quedará registrada en el historial.
             </p>
           </div>
           <DialogFooter>
             <Button variant="outline" onClick={() => setDialogOpen(false)}>
               Cancelar
             </Button>
-            <Button onClick={handleDownloadAndSave} disabled={createDownload.isPending}>
+            <Button
+              onClick={handleDownloadAndSave}
+              disabled={createDownload.isPending}>
               <Download className="w-4 h-4 mr-2" />
               Descargar y registrar
             </Button>

--- a/hooks/zones/use-zones.ts
+++ b/hooks/zones/use-zones.ts
@@ -40,11 +40,17 @@ export function useMeterZoneQuery(meterId: string | null) {
   });
 }
 
-export function useZoneMetersQuery(id: string | null) {
+export function useZoneMetersQuery(
+  id: string | null,
+  period?: { startDate: string; endDate: string }
+) {
   return useQuery<ZoneMeter[]>({
-    queryKey: [...ZONES_KEY, id, "meters"],
+    queryKey: [...ZONES_KEY, id, "meters", period?.startDate, period?.endDate],
     queryFn: async () => {
-      const res = await fetch(`/api/zones/${id}/meters`);
+      const query = period
+        ? `?startDate=${encodeURIComponent(period.startDate)}&endDate=${encodeURIComponent(period.endDate)}`
+        : "";
+      const res = await fetch(`/api/zones/${id}/meters${query}`);
       if (!res.ok) throw new Error("Error al obtener medidores de la zona");
       return res.json();
     },

--- a/lib/export-csv.ts
+++ b/lib/export-csv.ts
@@ -1,5 +1,3 @@
-import { formatDateTimeAR } from "@/lib/utils";
-
 type CsvRow = Record<string, string | number | null | undefined>;
 
 function escapeCsvValue(value: string | number | null | undefined): string {
@@ -36,23 +34,40 @@ export function downloadZoneCsv(
   meters: Array<{
     id: string;
     dev_eui: string | null;
+    device_name: string;
+    meter_type: "SMART" | "MECHANICAL";
     userName: string | null;
+    status: string;
+    street_address: string | null;
     shortData: string | null;
-    cumulative_flow: string | null;
-    last_reading_value: string | null;
+    month_cumulative_flow: string | null;
+    last_reading_date: string | Date | null;
     last_reading_observations: string | null;
-  }>
+  }>,
+  period?: { startDate: string; endDate: string },
+  globalObservation?: string
 ): void {
+  const showValue = (value: string | null | undefined): string =>
+    value && value.trim().length > 0 ? value : "—";
+
   const rows: CsvRow[] = meters.map((m) => ({
-    "ID / DEV EUI": m.dev_eui ?? m.id,
-    "Apellido y Nombre": m.userName ?? "",
-    "Domicilio": m.shortData ?? "",
-    "Consumo (m³)": m.last_reading_value ?? m.cumulative_flow ?? "",
-    "Observaciones": m.last_reading_observations ?? "",
+    // Mismo orden/criterio que la tabla de zona.
+    "Tipo": m.meter_type === "MECHANICAL" ? "Mecánico" : "Inteligente",
+    "Dispositivo": showValue(m.device_name),
+    "Usuario": showValue(m.userName),
+    "Dirección": showValue(
+      m.meter_type === "MECHANICAL" ? m.street_address : m.shortData
+    ),
+    "Acumulado del periodo (m³)": showValue(m.month_cumulative_flow),
+    "Estado": showValue(m.status),
+    "Observación medidor": showValue(m.last_reading_observations),
+    "Observación descarga": showValue(globalObservation),
   }));
   const csv = toCsvString(rows);
-  const date = new Date().toISOString().slice(0, 10);
-  downloadCsv(csv, `zona-${zoneName.toLowerCase().replace(/\s+/g, "-")}-${date}.csv`);
+  const suffix = period
+    ? `${period.startDate}_${period.endDate}`
+    : new Date().toISOString().slice(0, 10);
+  downloadCsv(csv, `zona-${zoneName.toLowerCase().replace(/\s+/g, "-")}-${suffix}.csv`);
 }
 
 export async function downloadReadingsCsv(

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -37,3 +37,25 @@ export function formatDateTimeShortAR(date: Date | string): string {
     minute: "2-digit",
   });
 }
+
+/** YYYY-MM-DD en zona horaria Argentina (UTC-3). */
+export function getTodayDateInputAR(): string {
+  const parts = new Intl.DateTimeFormat("en-CA", {
+    timeZone: TZ,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).formatToParts(new Date());
+
+  const year = parts.find((p) => p.type === "year")?.value ?? "1970";
+  const month = parts.find((p) => p.type === "month")?.value ?? "01";
+  const day = parts.find((p) => p.type === "day")?.value ?? "01";
+  return `${year}-${month}-${day}`;
+}
+
+/** Formatea YYYY-MM-DD sin conversion de zona (evita corrimientos de dia). */
+export function formatDateInputAR(dateInput: string): string {
+  const [year, month, day] = dateInput.slice(0, 10).split("-");
+  if (!year || !month || !day) return dateInput;
+  return `${day}/${month}/${year}`;
+}

--- a/types/zones/zone-types.ts
+++ b/types/zones/zone-types.ts
@@ -28,6 +28,7 @@ export interface ZoneMeter {
   userName: string | null;
   shortData: string | null;
   cumulative_flow: string | null;
+  month_cumulative_flow: string | null;
   last_reading_value: string | null;
   last_reading_date: string | Date | null;
   last_reading_observations: string | null;


### PR DESCRIPTION
## Summary

This PR aligns the Zones detail period workflow end-to-end (UI, API, and CSV export) and fixes inconsistencies between table values and exported data.

### What changed

- Implemented period-aware zone meter fetching via `startDate`/`endDate`.
- Defaulted to current bimester behavior and added explicit current/previous bimester controls.
- Fixed timezone/date handling (UTC-3 aware boundaries) to avoid day-shift issues.
- Updated period consumption logic to:
  - **consumption = last cumulative reading in period - first cumulative reading in period**
- Ensured CSV export reflects the same columns/meaning as the zone table.
- Added support for both observation scopes in CSV:
  - `Observación medidor` (per-reading/per-meter)
  - `Observación descarga` (global notes for that download event)
- Improved visual hierarchy around period selection, CSV action, and download history.
- Displayed current zone name in header area (not only “Editar nombre”).

### Files touched

- `app/api/zones/[id]/meters/route.ts`
- `hooks/zones/use-zones.ts`
- `components/zonas/zone-detail.tsx`
- `components/zonas/zone-download-section.tsx`
- `lib/export-csv.ts`
- `lib/utils.ts`
- `types/zones/zone-types.ts`
- `app/api/zones/[id]/downloads/route.ts` (format/consistency changes)

## Why

Users were seeing mismatches between:
- table period values vs CSV values,
- selected period vs displayed period in dialogs,
- and timezone-related date boundaries near midnight.

This PR makes the period flow deterministic and consistent for operational use.

## Test plan

- [ ] Open a zone detail and verify current bimester is selected by default.
- [ ] Switch between `Bimestre actual`, `Bimestre anterior`, and custom dates; confirm table updates.
- [ ] Validate period label matches selected inputs exactly.
- [ ] Download CSV and verify:
  - columns match table semantics,
  - `Acumulado del periodo (m³)` equals table values,
  - both observation fields are present and populated correctly.
- [ ] Add a global download note and confirm it appears in:
  - download history,
  - CSV `Observación descarga`.
- [ ] Confirm no date rollback/rollforward around local midnight (UTC-3).

## Risk / impact

Low-to-medium. Changes are scoped to zones period/read/export flow and typed contracts. No schema changes.