### PR TITLE
chore: add two-phase VPS deployment workflow

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+.git
+.github
+.next
+node_modules
+npm-debug.log
+deploy/env/.env.production
+deploy/backups
+.env
+.env.local
+.env.*.local

--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,8 @@ yarn-error.log*
 
 # local env files
 .env*.local
+deploy/env/.env.production
+deploy/backups/
 
 # vercel
 .vercel

--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -1,0 +1,35 @@
+import { NextResponse } from "next/server";
+import { PrismaClient } from "@prisma/client";
+
+const prisma = new PrismaClient();
+
+export async function GET() {
+  try {
+    await prisma.$queryRaw`SELECT 1`;
+
+    return NextResponse.json(
+      {
+        status: "ok",
+        timestamp: new Date().toISOString(),
+        checks: {
+          database: "ok",
+        },
+      },
+      { status: 200 }
+    );
+  } catch (error) {
+    return NextResponse.json(
+      {
+        status: "error",
+        timestamp: new Date().toISOString(),
+        checks: {
+          database: "error",
+        },
+        details: error instanceof Error ? error.message : "Unknown error",
+      },
+      { status: 503 }
+    );
+  } finally {
+    await prisma.$disconnect();
+  }
+}

--- a/deploy/compose/docker-compose.prod.yml
+++ b/deploy/compose/docker-compose.prod.yml
@@ -1,0 +1,51 @@
+name: ecowater
+
+services:
+  postgres:
+    image: postgres:16-alpine
+    container_name: ecowater-postgres
+    restart: unless-stopped
+    env_file:
+      - ../env/.env.production
+    environment:
+      POSTGRES_DB: ${POSTGRES_DB}
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+    volumes:
+      - ecowater_postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $$POSTGRES_USER -d $$POSTGRES_DB"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+    networks:
+      - ecowater_net
+
+  app:
+    container_name: ecowater-app
+    restart: unless-stopped
+    build:
+      context: ../..
+      dockerfile: deploy/docker/Dockerfile
+    env_file:
+      - ../env/.env.production
+    depends_on:
+      postgres:
+        condition: service_healthy
+    ports:
+      - "127.0.0.1:3000:3000"
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:3000/api/health >/dev/null 2>&1 || exit 1"]
+      interval: 30s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+    networks:
+      - ecowater_net
+
+volumes:
+  ecowater_postgres_data:
+
+networks:
+  ecowater_net:
+    driver: bridge

--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -1,0 +1,33 @@
+FROM node:20-alpine AS deps
+WORKDIR /app
+RUN apk add --no-cache openssl
+COPY package*.json ./
+COPY prisma ./prisma
+RUN npm ci
+
+FROM node:20-alpine AS builder
+WORKDIR /app
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+RUN npm run build
+
+FROM node:20-alpine AS runner
+WORKDIR /app
+
+ENV NODE_ENV=production
+ENV NEXT_TELEMETRY_DISABLED=1
+ENV PORT=3000
+
+RUN apk add --no-cache openssl postgresql-client
+
+COPY --from=builder /app/public ./public
+COPY --from=builder /app/prisma ./prisma
+COPY --from=builder /app/.next/standalone ./
+COPY --from=builder /app/.next/static ./.next/static
+
+COPY deploy/docker/entrypoint.sh /entrypoint.sh
+RUN sed -i 's/\r$//' /entrypoint.sh && chmod +x /entrypoint.sh
+
+EXPOSE 3000
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/deploy/docker/entrypoint.sh
+++ b/deploy/docker/entrypoint.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+set -e
+
+MAX_ATTEMPTS="${DB_CONNECT_MAX_ATTEMPTS:-20}"
+SLEEP_SECONDS="${DB_CONNECT_SLEEP_SECONDS:-3}"
+ATTEMPT=1
+SKIP_MIGRATIONS="${SKIP_DB_MIGRATIONS:-false}"
+
+if [ "$SKIP_MIGRATIONS" = "true" ]; then
+  echo "[entrypoint] SKIP_DB_MIGRATIONS=true, skipping Prisma migrate deploy."
+else
+  echo "[entrypoint] Checking database connectivity with Prisma..."
+  until npx prisma migrate deploy >/tmp/prisma-migrate.log 2>&1; do
+    if [ "$ATTEMPT" -ge "$MAX_ATTEMPTS" ]; then
+      echo "[entrypoint] Database not reachable after ${MAX_ATTEMPTS} attempts."
+      cat /tmp/prisma-migrate.log
+      exit 1
+    fi
+
+    echo "[entrypoint] DB not ready yet (attempt ${ATTEMPT}/${MAX_ATTEMPTS}), retrying in ${SLEEP_SECONDS}s..."
+    ATTEMPT=$((ATTEMPT + 1))
+    sleep "$SLEEP_SECONDS"
+  done
+
+  echo "[entrypoint] Prisma migrations applied."
+fi
+
+echo "[entrypoint] Starting Next.js..."
+exec node server.js

--- a/deploy/docs/DB_MIGRATION_SUPABASE_TO_VPS.md
+++ b/deploy/docs/DB_MIGRATION_SUPABASE_TO_VPS.md
@@ -1,0 +1,37 @@
+# Database migration: Supabase Postgres -> VPS Postgres
+
+## Preconditions
+
+- `deploy/compose/docker-compose.prod.yml` exists and starts `postgres`.
+- `deploy/env/.env.production` has valid `POSTGRES_*` values.
+- You have Supabase DB credentials and network access.
+
+## 1) Start local VPS postgres container
+
+`docker compose -f deploy/compose/docker-compose.prod.yml --env-file deploy/env/.env.production up -d postgres`
+
+## 2) Create dump from Supabase
+
+Use a machine with access to Supabase and `pg_dump` installed:
+
+`pg_dump --no-owner --no-acl --format=plain --dbname "postgresql://USER:PASSWORD@HOST:5432/postgres?sslmode=require" > supabase_dump.sql`
+
+If your DB name is not `postgres`, replace it accordingly.
+
+## 3) Restore dump into VPS postgres container
+
+`cat supabase_dump.sql | docker exec -i -e PGPASSWORD=$POSTGRES_PASSWORD ecowater-postgres psql -U $POSTGRES_USER -d $POSTGRES_DB`
+
+## 4) Validate schema and data
+
+1. Run migrations (safe no-op if already aligned):
+   - `docker compose -f deploy/compose/docker-compose.prod.yml --env-file deploy/env/.env.production run --rm app npx prisma migrate deploy`
+2. Quick row count check:
+   - `docker exec -e PGPASSWORD=$POSTGRES_PASSWORD ecowater-postgres psql -U $POSTGRES_USER -d $POSTGRES_DB -c "\\dt"`
+
+## 5) Cutover checklist
+
+- Confirm app login works.
+- Confirm dashboard data loads.
+- Confirm cron endpoint updates meter statuses.
+- Keep Supabase read-only backup until VPS is stable.

--- a/deploy/docs/DEPLOY_VPS.md
+++ b/deploy/docs/DEPLOY_VPS.md
@@ -1,0 +1,97 @@
+# Deploy VPS Runbook
+
+This runbook is intentionally split in two phases:
+
+- **Phase 1:** Move app runtime to VPS, keep Supabase as database.
+- **Phase 2:** Migrate database to PostgreSQL running on the VPS.
+
+## 1) First-time setup on VPS
+
+1. Clone repository into target directory.
+2. Copy environment template:
+   - `cp deploy/env/.env.example deploy/env/.env.production`
+3. Fill `deploy/env/.env.production` with production values.
+
+## 2) Phase 1: App on VPS + Supabase DB
+
+Use this phase to validate Dockerized runtime without touching production schema migrations.
+
+### Environment requirements
+
+- Keep `DATABASE_URL` and `DIRECT_URL` pointing to Supabase.
+- Set `SKIP_DB_MIGRATIONS=true` to avoid running `prisma migrate deploy` against production DB.
+- Keep all external keys configured (`AUTH_SECRET`, `CRON_SECRET`, Maps, Firebase, CRM if used).
+
+### Deploy steps
+
+1. Build and start:
+   - `docker compose -f deploy/compose/docker-compose.prod.yml --env-file deploy/env/.env.production up -d --build`
+2. Check health:
+   - `curl -fsS http://127.0.0.1:3000/api/health`
+3. Check logs:
+   - `docker compose -f deploy/compose/docker-compose.prod.yml --env-file deploy/env/.env.production logs -f app`
+4. Confirm login and dashboard in browser.
+
+## 3) Nginx and TLS on VPS
+
+1. Copy `deploy/nginx/ecowater.conf` to `/etc/nginx/sites-available/ecowater`.
+2. Update `server_name` with real domain or temporary host.
+3. Enable site:
+   - `sudo ln -s /etc/nginx/sites-available/ecowater /etc/nginx/sites-enabled/ecowater`
+4. Validate and reload:
+   - `sudo nginx -t`
+   - `sudo systemctl reload nginx`
+5. Issue TLS cert when domain is ready:
+   - `sudo certbot --nginx -d your-domain -d www.your-domain`
+
+## 4) Cron job (host)
+
+Install a host crontab entry:
+
+`0 6 * * * cd /path/to/repo && bash deploy/scripts/run-meter-cron.sh >> /var/log/ecowater-cron.log 2>&1`
+
+This replaces Vercel cron and calls:
+- `POST /api/cron/update-meter-status`
+
+## 5) Phase 2: Migrate DB from Supabase to VPS Postgres
+
+When Phase 1 is stable, move DB to VPS.
+
+### Environment changes for cutover
+
+1. Update `.env.production`:
+   - Set `DATABASE_URL` and `DIRECT_URL` to `postgres:5432` service URLs.
+   - Set real `POSTGRES_DB`, `POSTGRES_USER`, `POSTGRES_PASSWORD`.
+2. Set `SKIP_DB_MIGRATIONS=false` for controlled migration apply on startup.
+
+### Migration steps
+
+Follow `deploy/docs/DB_MIGRATION_SUPABASE_TO_VPS.md`:
+
+1. Dump Supabase DB.
+2. Restore into VPS postgres container.
+3. Run `prisma migrate deploy`.
+4. Validate login, dashboard data, and cron behavior.
+
+## 6) Daily operations
+
+- Deploy latest:
+  - `bash deploy/scripts/deploy.sh`
+- Check service health:
+  - `curl -fsS http://127.0.0.1:3000/api/health`
+- Follow app logs:
+  - `docker compose -f deploy/compose/docker-compose.prod.yml --env-file deploy/env/.env.production logs -f app`
+
+## 7) Backups
+
+- Create DB backup:
+  - `bash deploy/scripts/backup-db.sh`
+- Restore DB backup:
+  - `bash deploy/scripts/restore-db.sh deploy/backups/ecowater_YYYYMMDD_HHMMSS.sql.gz`
+
+## 8) Rollback
+
+`bash deploy/scripts/rollback.sh <git-ref>`
+
+Example:
+- `bash deploy/scripts/rollback.sh HEAD~1`

--- a/deploy/env/.env.example
+++ b/deploy/env/.env.example
@@ -1,0 +1,39 @@
+# App
+NODE_ENV=production
+APP_BASE_URL=https://ecowater.example.com
+NEXT_PUBLIC_NAME=EcoWater
+PORT=3000
+
+# Auth
+AUTH_SECRET=replace_with_strong_random_secret
+# Optional fallback supported by auth code:
+NEXTAUTH_SECRET=replace_with_strong_random_secret
+
+# Cron endpoint protection
+CRON_SECRET=replace_with_strong_random_secret
+SKIP_DB_MIGRATIONS=false
+
+# PostgreSQL container credentials
+POSTGRES_DB=ecowater
+POSTGRES_USER=ecowater
+POSTGRES_PASSWORD=replace_with_strong_password
+
+# Prisma connection strings (inside Docker network)
+DATABASE_URL=postgresql://ecowater:replace_with_strong_password@postgres:5432/ecowater?schema=public
+DIRECT_URL=postgresql://ecowater:replace_with_strong_password@postgres:5432/ecowater?schema=public
+
+# CRM integration
+CRM_URL=https://crm.example.com
+CRM_API_KEY=replace_with_crm_api_key
+
+# Google Maps
+NEXT_PUBLIC_GOOGLE_MAPS_API_KEY=replace_with_google_maps_api_key
+
+# Firebase
+NEXT_PUBLIC_FIREBASE_API_KEY=
+NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN=
+NEXT_PUBLIC_FIREBASE_PROJECT_ID=
+NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET=
+NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID=
+NEXT_PUBLIC_FIREBASE_APP_ID=
+NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID=

--- a/deploy/nginx/ecowater.conf
+++ b/deploy/nginx/ecowater.conf
@@ -1,0 +1,16 @@
+server {
+    listen 80;
+    listen [::]:80;
+    server_name ecowater.example.com www.ecowater.example.com;
+
+    location / {
+        proxy_pass http://127.0.0.1:3000;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+    }
+}

--- a/deploy/scripts/backup-db.sh
+++ b/deploy/scripts/backup-db.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+ENV_FILE="$ROOT_DIR/deploy/env/.env.production"
+BACKUP_DIR="$ROOT_DIR/deploy/backups"
+TIMESTAMP="$(date +%Y%m%d_%H%M%S)"
+OUTPUT_FILE="$BACKUP_DIR/ecowater_${TIMESTAMP}.sql.gz"
+
+mkdir -p "$BACKUP_DIR"
+
+set -a
+source "$ENV_FILE"
+set +a
+
+echo "[backup] Creating PostgreSQL dump..."
+docker exec -e PGPASSWORD="$POSTGRES_PASSWORD" ecowater-postgres \
+  pg_dump -U "$POSTGRES_USER" -d "$POSTGRES_DB" | gzip > "$OUTPUT_FILE"
+
+echo "[backup] Saved to $OUTPUT_FILE"

--- a/deploy/scripts/deploy.sh
+++ b/deploy/scripts/deploy.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+COMPOSE_FILE="$ROOT_DIR/deploy/compose/docker-compose.prod.yml"
+
+echo "[deploy] Pulling latest changes..."
+git -C "$ROOT_DIR" pull --ff-only
+
+echo "[deploy] Building and starting services..."
+docker compose -f "$COMPOSE_FILE" --env-file "$ROOT_DIR/deploy/env/.env.production" up -d --build
+
+echo "[deploy] Current status:"
+docker compose -f "$COMPOSE_FILE" ps

--- a/deploy/scripts/restore-db.sh
+++ b/deploy/scripts/restore-db.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -lt 1 ]]; then
+  echo "Usage: $0 <backup-file.sql.gz>"
+  exit 1
+fi
+
+BACKUP_FILE="$1"
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+ENV_FILE="$ROOT_DIR/deploy/env/.env.production"
+
+if [[ ! -f "$BACKUP_FILE" ]]; then
+  echo "Backup file not found: $BACKUP_FILE"
+  exit 1
+fi
+
+set -a
+source "$ENV_FILE"
+set +a
+
+echo "[restore] Restoring $BACKUP_FILE ..."
+gunzip -c "$BACKUP_FILE" | docker exec -i -e PGPASSWORD="$POSTGRES_PASSWORD" ecowater-postgres \
+  psql -U "$POSTGRES_USER" -d "$POSTGRES_DB"
+
+echo "[restore] Restore completed."

--- a/deploy/scripts/rollback.sh
+++ b/deploy/scripts/rollback.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -lt 1 ]]; then
+  echo "Usage: $0 <git-ref>"
+  exit 1
+fi
+
+TARGET_REF="$1"
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+COMPOSE_FILE="$ROOT_DIR/deploy/compose/docker-compose.prod.yml"
+
+echo "[rollback] Fetching refs..."
+git -C "$ROOT_DIR" fetch --all --prune
+
+echo "[rollback] Checking out $TARGET_REF ..."
+git -C "$ROOT_DIR" checkout "$TARGET_REF"
+
+echo "[rollback] Rebuilding and starting services..."
+docker compose -f "$COMPOSE_FILE" --env-file "$ROOT_DIR/deploy/env/.env.production" up -d --build
+
+echo "[rollback] Done."

--- a/deploy/scripts/run-meter-cron.sh
+++ b/deploy/scripts/run-meter-cron.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+ENV_FILE="$ROOT_DIR/deploy/env/.env.production"
+
+set -a
+source "$ENV_FILE"
+set +a
+
+APP_URL="${APP_BASE_URL:-https://ecowater.example.com}"
+
+curl --fail --show-error --silent \
+  -X POST \
+  -H "Authorization: Bearer ${CRON_SECRET}" \
+  "${APP_URL}/api/cron/update-meter-status"

--- a/lib/authOptions.ts
+++ b/lib/authOptions.ts
@@ -4,9 +4,13 @@ import bcrypt from "bcryptjs";
 import { PrismaClient } from "@prisma/client";
 
 const prisma = new PrismaClient();
+const authSecret =
+  process.env.AUTH_SECRET ||
+  process.env.NEXTAUTH_SECRET ||
+  process.env.NEXT_PUBLIC_AUTH_SECRET;
 
 export const authOptions: NextAuthOptions = {
-  secret: process.env.NEXT_PUBLIC_AUTH_SECRET,
+  secret: authSecret,
   providers: [
     CredentialsProvider({
       name: "Credentials",

--- a/middleware.ts
+++ b/middleware.ts
@@ -3,11 +3,15 @@ import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
 
 const LECTOR_ALLOWED = ["/dashboard/mapa", "/dashboard/zonas"];
+const authSecret =
+  process.env.AUTH_SECRET ||
+  process.env.NEXTAUTH_SECRET ||
+  process.env.NEXT_PUBLIC_AUTH_SECRET;
 
 export async function middleware(req: NextRequest) {
   const token = await getToken({
     req,
-    secret: process.env.NEXT_PUBLIC_AUTH_SECRET,
+    secret: authSecret,
   });
 
   if (!token) return NextResponse.next();

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,5 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  output: "standalone",
   images: {
     remotePatterns: [
       {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "postinstall": "npx dotenv -e .env.local -- prisma generate",
+    "postinstall": "prisma generate",
     "lint": "next lint",
     "format": "prettier --write .",
     "prisma:generate": "npx dotenv -e .env.local -- prisma generate",
@@ -15,14 +15,14 @@
     "prisma:push": "npx dotenv -e .env.local -- prisma db push && npm run prisma:generate",
     "prisma:studio": "npx dotenv -e .env.local -- prisma studio",
     "prisma:migrate": "npx dotenv -e .env.local -- prisma migrate dev",
+    "prisma:migrate:deploy": "prisma migrate deploy",
     "prisma:migrate:safe": "npx dotenv -e .env.local -- prisma migrate dev --create-only",
     "prisma:migrate:resolve": "npx dotenv -e .env.local -- prisma migrate resolve --applied",
     "prisma:reset": "npx dotenv -e .env.local -- prisma migrate reset",
     "dotenv": "npx dotenv -e .env.local --",
     "cron:update-meters": "curl -X POST http://localhost:3000/api/cron/update-meter-status",
     "cron:check-status": "curl -X GET http://localhost:3000/api/cron/update-meter-status",
-    "cron:test": "node scripts/test-cron.js",
-    "cron:test:prod": "node scripts/test-cron.js https://tu-app.vercel.app"
+    "cron:run:vps": "bash deploy/scripts/run-meter-cron.sh"
   },
   "prisma": {
     "seed": "tsx prisma/seed.ts"

--- a/vercel.json
+++ b/vercel.json
@@ -1,8 +1,1 @@
-{
-  "crons": [
-    {
-      "path": "/api/cron/update-meter-status",
-      "schedule": "0 6 * * *"
-    }
-  ]
-}
+{}


### PR DESCRIPTION
Add Docker/Nginx/compose deploy assets and production runbooks for a staged migration. The first phase keeps Supabase while running the app on VPS, and the second phase migrates data to local Postgres on the VPS.

Made-with: Cursor