### PR TITLE
fix(deploy): remove duplicate mqtt service in prod compose

### DIFF
--- a/deploy/compose/docker-compose.prod.yml
+++ b/deploy/compose/docker-compose.prod.yml
@@ -36,6 +36,7 @@ services:
       - ../mqtt/log:/mosquitto/log
     networks:
       - ecowater_net
+
   app:
     container_name: ecowater-app
     restart: unless-stopped
@@ -69,20 +70,6 @@ services:
       timeout: 5s
       retries: 5
       start_period: 30s
-    networks:
-      - ecowater_net
-
-  mqtt:
-    image: eclipse-mosquitto:2
-    container_name: ecowater-mqtt
-    restart: unless-stopped
-    volumes:
-      - /var/www/ecowater/mqtt/config:/mosquitto/config
-      - /var/www/ecowater/mqtt/data:/mosquitto/data
-      - /var/www/ecowater/mqtt/log:/mosquitto/log
-    ports:
-      - "1883:1883"
-      - "8883:8883"
     networks:
       - ecowater_net
 


### PR DESCRIPTION
## Problem
`main` currently has **two** `mqtt:` service definitions in `docker-compose.prod.yml` (introduced when #54 merged). YAML rejects duplicate keys, so the whole compose fails to parse:

```
yaml: mapping key "mqtt" already defined at line 24
```

`docker compose up` is broken on main right now — this blocks any deploy.

## Fix
Remove the duplicate (the absolute-path `/var/www/ecowater/mqtt` variant), keeping the relative-path service (`../mqtt/...`) that is consistent with the runtime paths gitignored under `deploy/mqtt/`.

Verified with `docker compose config` → parses clean, services: postgres, app, mqtt.